### PR TITLE
release v0.2.0 gov-krs

### DIFF
--- a/docs/install/fin/install.yaml
+++ b/docs/install/fin/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.fin-ntruss.com
         - --base-path=/ncloud/v1
-        image: io.ncr.fin-ntruss.com/nks/alb-ingress-controller:0.0.6
+        image: io.ncr.fin-ntruss.com/nks/alb-ingress-controller:0.2.0
         name: alb-ingress-controller
         resources:
           limits:

--- a/docs/install/fin/install.yaml
+++ b/docs/install/fin/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.fin-ntruss.com
         - --base-path=/ncloud/v1
-        image: io.ncr.fin-ntruss.com/nks/alb-ingress-controller:0.2.0
+        image: io.ncr.fin-ntruss.com/nks/alb-ingress-controller:0.1.0
         name: alb-ingress-controller
         resources:
           limits:

--- a/docs/install/gov-krs/install.yaml
+++ b/docs/install/gov-krs/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.gov-ntruss.com
         - --base-path=/ncloud/krs-v1
-        image: io.ncr.gov-ntruss.com/nks/alb-ingress-controller:0.1.0
+        image: io.ncr.gov-ntruss.com/nks/alb-ingress-controller:0.2.0
         name: alb-ingress-controller
         resources:
           limits:

--- a/docs/install/gov/install.yaml
+++ b/docs/install/gov/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.gov-ntruss.com
         - --base-path=/ncloud/v1
-        image: io.ncr.gov-ntruss.com/nks/alb-ingress-controller:0.0.6
+        image: io.ncr.gov-ntruss.com/nks/alb-ingress-controller:0.2.0
         name: alb-ingress-controller
         resources:
           limits:

--- a/docs/install/gov/install.yaml
+++ b/docs/install/gov/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.gov-ntruss.com
         - --base-path=/ncloud/v1
-        image: io.ncr.gov-ntruss.com/nks/alb-ingress-controller:0.2.0
+        image: io.ncr.gov-ntruss.com/nks/alb-ingress-controller:0.1.0
         name: alb-ingress-controller
         resources:
           limits:

--- a/docs/install/pub/install.yaml
+++ b/docs/install/pub/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.ntruss.com
         - --base-path=/ncloud/v1
-        image: io.kr.ncr.ntruss.com/nks/alb-ingress-controller:0.0.6
+        image: io.kr.ncr.ntruss.com/nks/alb-ingress-controller:0.2.0
         name: alb-ingress-controller
         resources:
           limits:

--- a/docs/install/pub/install.yaml
+++ b/docs/install/pub/install.yaml
@@ -103,7 +103,7 @@ spec:
         args:
         - --api-url=nks.apigw.ntruss.com
         - --base-path=/ncloud/v1
-        image: io.kr.ncr.ntruss.com/nks/alb-ingress-controller:0.2.0
+        image: io.kr.ncr.ntruss.com/nks/alb-ingress-controller:0.1.0
         name: alb-ingress-controller
         resources:
           limits:


### PR DESCRIPTION
- `v0.1.0` -> `v0.2.0 ` upgrade 할 경우 targegroup, loadbalancer 재생성 됨