### PR TITLE
chore: update install manifest

### DIFF
--- a/docs/install/fin/install.yaml
+++ b/docs/install/fin/install.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: alb-ingress-controller
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: alb-ingress-controller
@@ -64,7 +64,7 @@ rules:
       - update
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: alb-ingress-controller

--- a/docs/install/gov-krs/install.yaml
+++ b/docs/install/gov-krs/install.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: alb-ingress-controller
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: alb-ingress-controller
@@ -64,7 +64,7 @@ rules:
       - update
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: alb-ingress-controller

--- a/docs/install/gov/install.yaml
+++ b/docs/install/gov/install.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: alb-ingress-controller
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: alb-ingress-controller
@@ -64,7 +64,7 @@ rules:
       - update
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: alb-ingress-controller

--- a/docs/install/pub/install.yaml
+++ b/docs/install/pub/install.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: alb-ingress-controller
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: alb-ingress-controller
@@ -64,7 +64,7 @@ rules:
       - update
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: alb-ingress-controller


### PR DESCRIPTION
Authentication.k8s.io/v1beta1 and authorization.k8s.io/v1beta1 are deprecated in 1.19 in favor of v1 levels and will be removed in 1.22