### PR TITLE
가이드 예제로 사용하고 있는 기존 gist manifest 이동

### DIFF
--- a/docs/examples/fin/nks-alb-ingress-sample-services.yaml
+++ b/docs/examples/fin/nks-alb-ingress-sample-services.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: naver
+spec:
+  type: NodePort
+  selector:
+    app: naver
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: naver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: naver
+  template:
+    metadata:
+      labels:
+        app: naver
+    spec:
+      containers:
+        - name: naver
+          image: nks.private-ncr.fin-ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud
+spec:
+  type: NodePort
+  selector:
+    app: cloud
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloud
+  template:
+    metadata:
+      labels:
+        app: cloud
+    spec:
+      containers:
+        - name: cloud
+          image: nks.private-ncr.fin-ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: platform
+spec:
+  type: NodePort
+  selector:
+    app: platform
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platform
+  template:
+    metadata:
+      labels:
+        app: platform
+    spec:
+      containers:
+        - name: platform
+          image: nks.private-ncr.fin-ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80

--- a/docs/examples/gov/nks-alb-ingress-sample-services.yaml
+++ b/docs/examples/gov/nks-alb-ingress-sample-services.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: naver
+spec:
+  type: NodePort
+  selector:
+    app: naver
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: naver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: naver
+  template:
+    metadata:
+      labels:
+        app: naver
+    spec:
+      containers:
+        - name: naver
+          image: nks.private-ncr.gov-ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud
+spec:
+  type: NodePort
+  selector:
+    app: cloud
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloud
+  template:
+    metadata:
+      labels:
+        app: cloud
+    spec:
+      containers:
+        - name: cloud
+          image: nks.private-ncr.gov-ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: platform
+spec:
+  type: NodePort
+  selector:
+    app: platform
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platform
+  template:
+    metadata:
+      labels:
+        app: platform
+    spec:
+      containers:
+        - name: platform
+          image: nks.private-ncr.gov-ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80

--- a/docs/examples/pub/nks-alb-ingress-sample-services.yaml
+++ b/docs/examples/pub/nks-alb-ingress-sample-services.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: naver
+spec:
+  type: NodePort
+  selector:
+    app: naver
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: naver
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: naver
+  template:
+    metadata:
+      labels:
+        app: naver
+    spec:
+      containers:
+        - name: naver
+          image: nks.kr.private-ncr.ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud
+spec:
+  type: NodePort
+  selector:
+    app: cloud
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloud
+  template:
+    metadata:
+      labels:
+        app: cloud
+    spec:
+      containers:
+        - name: cloud
+          image: nks.kr.private-ncr.ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: platform
+spec:
+  type: NodePort
+  selector:
+    app: platform
+  ports:
+    - port: 80
+      targetPort: 80
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: platform
+  template:
+    metadata:
+      labels:
+        app: platform
+    spec:
+      containers:
+        - name: platform
+          image: nks.kr.private-ncr.ntruss.com/hello:plain-text
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
- 기존 manifest: https://gist.githubusercontent.com/NaverCloudPlatformDeveloper/0e6262b996f74229719807cb5ae007fc/raw/3ce72e7961bc2407bfb87e153c94672e6ee6a1cf/nks-alb-ingress-sample-services.yaml
- ncr 주소 수정
- 도메인 별 관리